### PR TITLE
10 keep vector column info

### DIFF
--- a/src/geoapis/vector.py
+++ b/src/geoapis/vector.py
@@ -78,8 +78,8 @@ class Linz:
         catchment_bounds = self.catchment_polygon.geometry.bounds
         feature_collection = self.query_vector_wfs(catchment_bounds, layer, geometry_type)
 
-        # Cycle through each feature getting name and coordinates
-        features = []
+        # Cycle through each feature checking in bounds and getting geometry and properties
+        features = {'geometry': []}
         for feature in feature_collection['features']:
 
             shapely_geometry = shapely.geometry.shape(feature['geometry'])
@@ -87,16 +87,23 @@ class Linz:
             # check intersection of tile and catchment in LINZ CRS
             if self.catchment_polygon.intersects(shapely_geometry).any():
 
-                # convert any one Polygon MultiPolygons to a straight Polygon
+                # Create 'properties' column headings from first in-bounds vector
+                if len(features['geometry']) == 0:
+                    for key in feature['properties'].keys():
+                        features[key] = []
+
+                # Convert any one Polygon MultiPolygons to a straight Polygon then add to the geometries
                 if (shapely_geometry.geometryType() == 'MultiPolygon' and len(shapely_geometry) == 1):
                     shapely_geometry = shapely_geometry[0]
+                features['geometry'].append(shapely_geometry)
 
-                features.append(shapely_geometry)
+                # Add the value of each property in turn
+                for key in feature['properties'].keys():
+                    features[key].append(feature['properties'][key])
 
         # Convert to a geopandas dataframe
         if len(features) > 0:
-            features = geopandas.GeoDataFrame(index=list(range(len(features))), geometry=features,
-                                              crs=self.catchment_polygon.crs)
+            features = geopandas.GeoDataFrame(features, crs=self.catchment_polygon.crs)
         else:
             features = None
 

--- a/src/geoapis/vector.py
+++ b/src/geoapis/vector.py
@@ -87,12 +87,12 @@ class Linz:
             # check intersection of tile and catchment in LINZ CRS
             if self.catchment_polygon.intersects(shapely_geometry).any():
 
-                # Create 'properties' column headings from first in-bounds vector
+                # Create column headings for each 'properties' option from the first in-bounds vector
                 if len(features['geometry']) == 0:
                     for key in feature['properties'].keys():
-                        features[key] = []
+                        features[key] = []  # The empty list to append the property values too
 
-                # Convert any one Polygon MultiPolygons to a straight Polygon then add to the geometries
+                # Convert any one Polygon MultiPolygon to a straight Polygon then add to the geometries
                 if (shapely_geometry.geometryType() == 'MultiPolygon' and len(shapely_geometry) == 1):
                     shapely_geometry = shapely_geometry[0]
                 features['geometry'].append(shapely_geometry)

--- a/tests/test_vector/test_vector.py
+++ b/tests/test_vector/test_vector.py
@@ -95,15 +95,15 @@ class LinzVectorsTest(unittest.TestCase):
                                self.instructions['instructions']['apis']['linz']['land']['type'])
 
         # check various shape attributes match those expected
-        self.assertEqual(land.geometry.area.sum(), self.LAND['area'], "The area of the returned land polygon " +
-                         f"`{land.geometry.area.sum()}` differs from the expected {self.LAND['area']}")
-        self.assertEqual(land.geometry.length.sum(), self.LAND['length'], "The length of the returned land polygon " +
-                         f"`{land.geometry.length.sum()}` differs from the expected {self.LAND['length']}")
         self.assertEqual(land.loc[0].geometry.geometryType(), self.LAND['geometryType'], "The geometryType of the " +
                          f"returned land polygon `{land.loc[0].geometry.geometryType()}` differs from the expected " +
                          f"{self.LAND['geometryType']}")
         self.assertEqual(list(land.columns), self.LAND['columns'], "The columns of the returned land polygon " +
                          f"`{list(land.columns)}` differ from the expected {self.LAND['columns']}")
+        self.assertEqual(land.geometry.area.sum(), self.LAND['area'], "The area of the returned land polygon " +
+                         f"`{land.geometry.area.sum()}` differs from the expected {self.LAND['area']}")
+        self.assertEqual(land.geometry.length.sum(), self.LAND['length'], "The length of the returned land polygon " +
+                         f"`{land.geometry.length.sum()}` differs from the expected {self.LAND['length']}")
 
     def test_bathymetry(self):
         """ A test to check expected bathyemtry contours are loaded """
@@ -113,19 +113,19 @@ class LinzVectorsTest(unittest.TestCase):
             self.instructions['instructions']['apis']['linz']['bathymetry_contours']['type'])
 
         # check various shape attributes match those expected
+        self.assertEqual(bathymetry_contours.loc[0].geometry.geometryType(), self.BATHYMETRY_CONTOURS['geometryType'],
+                         "The geometryType of the returned land polygon " +
+                         f"`{bathymetry_contours.loc[0].geometry.geometryType()}` differs from the expected " +
+                         f"{self.BATHYMETRY_CONTOURS['geometryType']}")
+        self.assertEqual(list(bathymetry_contours.columns), self.BATHYMETRY_CONTOURS['columns'], "The columns of the" +
+                         f" returned land polygon `{list(bathymetry_contours.columns)}` differ from the expected " +
+                         f"{self.BATHYMETRY_CONTOURS['columns']}")
         self.assertEqual(bathymetry_contours.geometry.area.sum(), self.BATHYMETRY_CONTOURS['area'], "The area of the " +
                          f"returned bathymetry_contours polygon `{bathymetry_contours.geometry.area.sum()}` differs " +
                          "from the expected {self.BATHYMETRY_CONTOURS['area']}")
         self.assertEqual(bathymetry_contours.geometry.length.sum(), self.BATHYMETRY_CONTOURS['length'], "The area of " +
                          f"the returned bathymetry_contours polygon `{bathymetry_contours.geometry.length.sum()}` " +
                          "differs from the expected {self.BATHYMETRY_CONTOURS['length']}")
-        self.assertEqual(bathymetry_contours.loc[0].geometry.geometryType(), self.BATHYMETRY_CONTOURS['geometryType'],
-                         "The geometryType of the returned land polygon " +
-                         f"`{bathymetry_contours.loc[0].geometry.geometryType()}` differs from the expected " +
-                         f"{self.BATHYMETRY_CONTOURS['length']}")
-        self.assertEqual(list(bathymetry_contours.columns), self.BATHYMETRY_CONTOURS['columns'], "The columns of the" +
-                         f" returned land polygon `{list(bathymetry_contours.columns)}` differ from the expected " +
-                         f"{self.BATHYMETRY_CONTOURS['columns']}")
 
 
 if __name__ == '__main__':

--- a/tests/test_vector/test_vector.py
+++ b/tests/test_vector/test_vector.py
@@ -27,8 +27,12 @@ class LinzVectorsTest(unittest.TestCase):
     """
 
     # The expected datasets and files to be downloaded - used for comparison in the later tests
-    LAND = {"area": 150539169542.39142, "geometryType": 'Polygon', 'length': 6006036.039821969}
-    BATHYMETRY_CONTOURS = {"area": 0.0, "geometryType": 'LineString', 'length': 144353.73387463146}
+    LAND = {"area": 150539169542.39142, "geometryType": 'Polygon', 'length': 6006036.039821969,
+            'columns': ['geometry', 'name', 'macronated', 'grp_macron', 'TARGET_FID', 'grp_ascii', 'grp_name',
+                        'name_ascii']}
+    BATHYMETRY_CONTOURS = {"area": 0.0, "geometryType": 'LineString', 'length': 144353.73387463146,
+                           'columns': ['geometry', 'fidn', 'valdco', 'verdat', 'inform', 'ninfom', 'ntxtds',
+                                       'scamin', 'txtdsc', 'sordat', 'sorind', 'hypcat']}
 
     @classmethod
     def setUpClass(cls):
@@ -97,7 +101,9 @@ class LinzVectorsTest(unittest.TestCase):
                          f"`{land.geometry.length.sum()}` differs from the expected {self.LAND['length']}")
         self.assertEqual(land.loc[0].geometry.geometryType(), self.LAND['geometryType'], "The geometryType of the " +
                          f"returned land polygon `{land.loc[0].geometry.geometryType()}` differs from the expected " +
-                         f"{self.LAND['length']}")
+                         f"{self.LAND['geometryType']}")
+        self.assertEqual(list(land.columns), self.LAND['columns'], "The columns of the returned land polygon " +
+                         f"`{list(land.columns)}` differ from the expected {self.LAND['columns']}")
 
     def test_bathymetry(self):
         """ A test to check expected bathyemtry contours are loaded """
@@ -117,6 +123,9 @@ class LinzVectorsTest(unittest.TestCase):
                          "The geometryType of the returned land polygon " +
                          f"`{bathymetry_contours.loc[0].geometry.geometryType()}` differs from the expected " +
                          f"{self.BATHYMETRY_CONTOURS['length']}")
+        self.assertEqual(list(bathymetry_contours.columns), self.BATHYMETRY_CONTOURS['columns'], "The columns of the" +
+                         f" returned land polygon `{list(bathymetry_contours.columns)}` differ from the expected " +
+                         f"{self.BATHYMETRY_CONTOURS['columns']}")
 
 
 if __name__ == '__main__':

--- a/tests/test_vector/test_vector.py
+++ b/tests/test_vector/test_vector.py
@@ -29,10 +29,11 @@ class LinzVectorsTest(unittest.TestCase):
     # The expected datasets and files to be downloaded - used for comparison in the later tests
     LAND = {"area": 150539169542.3913, "geometryType": 'Polygon', 'length': 6006036.039821965,
             'columns': ['geometry', 'name', 'macronated', 'grp_macron', 'TARGET_FID', 'grp_ascii', 'grp_name',
-                        'name_ascii']}
+                        'name_ascii'], 'name': ['South Island or Te Waipounamu']}
     BATHYMETRY_CONTOURS = {"area": 0.0, "geometryType": 'LineString', 'length': 144353.73387463146,
                            'columns': ['geometry', 'fidn', 'valdco', 'verdat', 'inform', 'ninfom', 'ntxtds',
-                                       'scamin', 'txtdsc', 'sordat', 'sorind', 'hypcat']}
+                                       'scamin', 'txtdsc', 'sordat', 'sorind', 'hypcat'],
+                           'valdco': [2.0, 2.0, 0.0, 0.0, 0.0, 0.0, 20.0, 0.0, 0.0, 5.0, 10.0, 30.0, 2.0, 0.0]}
 
     @classmethod
     def setUpClass(cls):
@@ -100,6 +101,8 @@ class LinzVectorsTest(unittest.TestCase):
                          f"{self.LAND['geometryType']}")
         self.assertEqual(list(land.columns), self.LAND['columns'], "The columns of the returned land polygon " +
                          f"`{list(land.columns)}` differ from the expected {self.LAND['columns']}")
+        self.assertEqual(list(land['name_ascii']), self.LAND['name'], "The value of the land polygon's 'name' column " +
+                         f"`{list(land['name_ascii'])}` differ from the expected {self.LAND['name']}")
         self.assertEqual(land.geometry.area.sum(), self.LAND['area'], "The area of the returned land polygon " +
                          f"`{land.geometry.area.sum()}` differs from the expected {self.LAND['area']}")
         self.assertEqual(land.geometry.length.sum(), self.LAND['length'], "The length of the returned land polygon " +
@@ -120,6 +123,9 @@ class LinzVectorsTest(unittest.TestCase):
         self.assertEqual(list(bathymetry_contours.columns), self.BATHYMETRY_CONTOURS['columns'], "The columns of the" +
                          f" returned land polygon `{list(bathymetry_contours.columns)}` differ from the expected " +
                          f"{self.BATHYMETRY_CONTOURS['columns']}")
+        self.assertEqual(list(bathymetry_contours['valdco']), self.BATHYMETRY_CONTOURS['valdco'], "The columns of the" +
+                         f" land polygon's 'valdco' column `{list(bathymetry_contours['valdco'])}` differ from the " +
+                         f"expected {self.BATHYMETRY_CONTOURS['valdco']}")
         self.assertEqual(bathymetry_contours.geometry.area.sum(), self.BATHYMETRY_CONTOURS['area'], "The area of the " +
                          f"returned bathymetry_contours polygon `{bathymetry_contours.geometry.area.sum()}` differs " +
                          "from the expected {self.BATHYMETRY_CONTOURS['area']}")

--- a/tests/test_vector/test_vector.py
+++ b/tests/test_vector/test_vector.py
@@ -27,7 +27,7 @@ class LinzVectorsTest(unittest.TestCase):
     """
 
     # The expected datasets and files to be downloaded - used for comparison in the later tests
-    LAND = {"area": 150539169542.39142, "geometryType": 'Polygon', 'length': 6006036.039821969,
+    LAND = {"area": 150539169542.3913, "geometryType": 'Polygon', 'length': 6006036.039821965,
             'columns': ['geometry', 'name', 'macronated', 'grp_macron', 'TARGET_FID', 'grp_ascii', 'grp_name',
                         'name_ascii']}
     BATHYMETRY_CONTOURS = {"area": 0.0, "geometryType": 'LineString', 'length': 144353.73387463146,


### PR DESCRIPTION
Extend geoapis.vector LINZ to also record all the 'properties' information associated with each vector in a column for each property in the geopandas.GeoDataFrame

- [x] Update geoapis.vector to pull out the 'properties' information
- [x] Update the tests to ensure the properties columns are added
- [x] Update the tests to ensure the values of one of the properties columns is as expected