### PR TITLE
8 vector linz class extension

### DIFF
--- a/src/geoapis/__init__.py
+++ b/src/geoapis/__init__.py
@@ -4,4 +4,4 @@ Created on Thu Jul  1 09:57:30 2021
 
 @author: pearsonra
 """
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/src/geoapis/vector.py
+++ b/src/geoapis/vector.py
@@ -141,7 +141,7 @@ class Linz:
         return features
 
 
-    def query_vector_wfs(self, bounds, layer: int, geometry_type: str):
+    def query_vector_wfs(self, layer: int):
         """ Function to check for all features associated with a layer using the LINZ WFS vector query API
         https://www.linz.govt.nz/data/linz-data-service/guides-and-documentation/wfs-spatial-filtering """
 

--- a/src/geoapis/vector.py
+++ b/src/geoapis/vector.py
@@ -98,7 +98,6 @@ class Linz:
                     if self.verbose:
                         print(f"Layer: {layer} is not of `geometry_name`: {geometry_name}. URL is: " +\
                               "{requests.Request('POST', data_url, params=params).prepare().url}")
-                    continue
             assert False, f"No geometry types matching that of layer: {layer} tried. The geometry_name's tried are: +" \
                 "{geometry_type_list}"
 

--- a/src/geoapis/vector.py
+++ b/src/geoapis/vector.py
@@ -94,7 +94,7 @@ class Linz:
                 try:
                     response.raise_for_status()
                     return response.json()
-                except urllib.error.HTTPError:
+                except urllib.error.HTTPError or requests.exceptions.HTTPError:
                     if self.verbose:
                         print(f"Layer: {layer} is not of `geometry_name`: {geometry_name}. URL is: " +\
                               "{requests.Request('POST', data_url, params=params).prepare().url}")

--- a/src/geoapis/vector.py
+++ b/src/geoapis/vector.py
@@ -18,7 +18,7 @@ class Linz:
     API details at: https://www.linz.govt.nz/data/linz-data-service/guides-and-documentation/wfs-spatial-filtering
 
     The specified vector layer is queried each time run is called and any vectors passing though the catchment defined
-    in the catchment_polygon are returned. 
+    in the catchment_polygon are returned.
 
     Flexibility exists in the inputs. Only the key is required. If no search_polygon is specified all features in a
     layer will be downloaded. If no crs is specified, the search_polygon will be used if the search_polygon is
@@ -50,6 +50,7 @@ class Linz:
         # Set the catchment_polygon crs from the crs if they differ
         if self.catchment_polygon is not None and self.crs != self.catchment_polygon.crs.to_epsg():
             self.catchment_polygon.to_crs(self.crs)
+
 
     def run(self, layer: int, geometry_name: str = ""):
         """ Query for tiles within a catchment for a specified layer and return a list of the vector features names

--- a/src/geoapis/vector.py
+++ b/src/geoapis/vector.py
@@ -30,9 +30,9 @@ class Linz:
     WFS_PATH_API_END = "/wfs"
     LINZ_GEOMETRY_NAMES = ['GEOMETRY', 'shape']
 
-    def __init__(self, key: str, crs: int = None, catchment_polygon: geopandas.geodataframe.GeoDataFrame = None, verbose: bool = False):
-        """ Load in vector information from LINZ. Specify the layer to import during run.
-        """
+    def __init__(self, key: str, crs: int = None, catchment_polygon: geopandas.geodataframe.GeoDataFrame = None,
+                 verbose: bool = False):
+        """ Load in vector information from LINZ. Specify the layer to import during run. """
 
         self.key = key
         self.catchment_polygon = catchment_polygon
@@ -40,7 +40,6 @@ class Linz:
         self.verbose = verbose
 
         self._set_up()
-
 
     def _set_up(self):
         # Set the crs from the catchment_polygon if it's not been set
@@ -50,7 +49,6 @@ class Linz:
         # Set the catchment_polygon crs from the crs if they differ
         if self.catchment_polygon is not None and self.crs != self.catchment_polygon.crs.to_epsg():
             self.catchment_polygon.to_crs(self.crs)
-
 
     def run(self, layer: int, geometry_name: str = ""):
         """ Query for tiles within a catchment for a specified layer and return a list of the vector features names
@@ -94,7 +92,6 @@ class Linz:
 
         return response
 
-
     def get_json_response_in_bounds(self, layer: int, bounds, geometry_name: str):
         """ Check for specified `geometry_name` - try the standard LINZ ones in turn if not specified - and check for
         error messages before returning  """
@@ -116,11 +113,10 @@ class Linz:
                     return response.json()
                 except requests.exceptions.HTTPError:
                     if self.verbose:
-                        print(f"Layer: {layer} is not of `geometry_name`: {geometry_name}. URL is: " +\
+                        print(f"Layer: {layer} is not of `geometry_name`: {geometry_name}. URL is: " +
                               "{requests.Request('POST', data_url, params=params).prepare().url}")
             assert False, f"No geometry types matching that of layer: {layer} tried. The geometry_name's tried are: +" \
                 "{geometry_type_list}"
-
 
     def get_features_inside_catchment(self, layer: int, geometry_name: str):
         """ Get a list of features within the catchment boundary """
@@ -162,7 +158,6 @@ class Linz:
             features = None
 
         return features
-
 
     def query_vector_wfs(self, layer: int):
         """ Function to check for all features associated with a layer using the LINZ WFS vector query API

--- a/src/geoapis/vector.py
+++ b/src/geoapis/vector.py
@@ -18,7 +18,11 @@ class Linz:
     API details at: https://www.linz.govt.nz/data/linz-data-service/guides-and-documentation/wfs-spatial-filtering
 
     The specified vector layer is queried each time run is called and any vectors passing though the catchment defined
-    in the catchment_polygon are returned. """
+    in the catchment_polygon are returned. 
+
+    Flexibility exists in the inputs. Only the key is required. If no search_polygon is specified all features in a
+    layer will be downloaded. If no crs is specified, the search_polygon will be used if the search_polygon is
+    specified. If no CRS or search_polygon is specified the CRS of the downloaded features will be used. """
 
     SCHEME = "https"
     NETLOC_API = "data.linz.govt.nz"
@@ -82,7 +86,7 @@ class Linz:
                           f"'urn:ogc:def:crs:{self.catchment_polygon.crs.to_string()}')"
         }
 
-        if self.crs is not None:  # Only specify crs if passed in
+        if self.crs is not None:  # Only specify crs if specified
             api_query["SRSName"] = f"EPSG:{self.crs}"
 
         response = requests.get(data_url, params=api_query, stream=True)
@@ -175,7 +179,7 @@ class Linz:
             "outputFormat": "json"
         }
 
-        if self.crs is not None:  # Only specify crs if passed in
+        if self.crs is not None:  # Only specify crs if specified
             api_query["SRSName"] = f"EPSG:{self.crs}"
 
         response = requests.get(data_url, params=api_query, stream=True)

--- a/src/geoapis/vector.py
+++ b/src/geoapis/vector.py
@@ -94,7 +94,7 @@ class Linz:
                 try:
                     response.raise_for_status()
                     return response.json()
-                except urllib.error.HTTPError or requests.exceptions.HTTPError:
+                except requests.exceptions.HTTPError:
                     if self.verbose:
                         print(f"Layer: {layer} is not of `geometry_name`: {geometry_name}. URL is: " +\
                               "{requests.Request('POST', data_url, params=params).prepare().url}")

--- a/src/geoapis/vector.py
+++ b/src/geoapis/vector.py
@@ -98,6 +98,7 @@ class Linz:
                     if self.verbose:
                         print(f"Layer: {layer} is not of `geometry_name`: {geometry_name}. URL is: " +\
                               "{requests.Request('POST', data_url, params=params).prepare().url}")
+                    continue
             assert False, f"No geometry types matching that of layer: {layer} tried. The geometry_name's tried are: +" \
                 "{geometry_type_list}"
 

--- a/src/geoapis/vector.py
+++ b/src/geoapis/vector.py
@@ -24,8 +24,9 @@ class Linz:
     NETLOC_API = "data.linz.govt.nz"
     WFS_PATH_API_START = "/services;key="
     WFS_PATH_API_END = "/wfs"
+    LINZ_GEOMETRY_TYPES = ['GEOMETRY', 'shape']
 
-    def __init__(self, key: str, catchment_polygon: geopandas.geodataframe.GeoDataFrame, verbose: bool = False):
+    def __init__(self, key: str, catchment_polygon: geopandas.geodataframe.GeoDataFrame = None, verbose: bool = False):
         """ Load in vector information from LINZ. Specify the layer to import during run.
         """
 
@@ -33,15 +34,18 @@ class Linz:
         self.catchment_polygon = catchment_polygon
         self.verbose = verbose
 
-    def run(self, layer: int, geometry_type: str):
+    def run(self, layer: int, geometry_type: str = ""):
         """ Query for tiles within a catchment for a specified layer and return a list of the vector features names
         within the catchment """
 
-        features = self.get_features_inside_catchment(layer, geometry_type)
+        if self.catchment_polygon is None:
+            features = self.get_features(layer)
+        else:
+            features = self.get_features_inside_catchment(layer, geometry_type)
 
         return features
 
-    def query_vector_wfs(self, bounds, layer: int, geometry_type: str):
+    def query_vector_wfs_in_bounds(self, layer: int, bounds, geometry_type: str):
         """ Function to check for tiles in search rectangle using the LINZ WFS vector query API
         https://www.linz.govt.nz/data/linz-data-service/guides-and-documentation/wfs-spatial-filtering
 
@@ -68,15 +72,42 @@ class Linz:
 
         response = requests.get(data_url, params=api_query, stream=True)
 
-        response.raise_for_status()
-        return response.json()
+        return response
+
+
+    def get_json_response_in_bounds(self, layer: int, bounds, geometry_type: str):
+        """ Check for specified `geometry_type` - try the standard LINZ ones in turn if not specified - and check for
+        error messages before returning  """
+
+        # If a geometry_type was specified use this, otherwise try the standard LINZ ones
+        if geometry_type is not None and geometry_type != "":
+
+            response = self.query_vector_wfs_in_bounds(layer, bounds, geometry_type)
+            response.raise_for_status()
+            return response.json()
+
+        else:
+
+            # cycle through the standard LINZ geometry_types - suppress errors and only raise one if no valid responses
+            for geometry_type in self.LINZ_GEOMETRY_TYPES:
+                response = self.query_vector_wfs_in_bounds(layer, bounds, geometry_type)
+                try:
+                    response.raise_for_status()
+                    return response.json()
+                except urllib.error.HTTPError:
+                    if self.verbose:
+                        print(f"Layer: {layer} is not of geometry type: {geometry_type}. URL is: " +\
+                              "{requests.Request('POST', data_url, params=params).prepare().url}")
+            assert False, f"No geometry types matching that of layer: {layer} tried. The geometry types tried are: +" \
+                "{geometry_type_list}"
+
 
     def get_features_inside_catchment(self, layer: int, geometry_type: str):
         """ Get a list of features within the catchment boundary """
 
         # radius in metres
         catchment_bounds = self.catchment_polygon.geometry.bounds
-        feature_collection = self.query_vector_wfs(catchment_bounds, layer, geometry_type)
+        feature_collection = self.get_json_response_in_bounds(layer, catchment_bounds, geometry_type)
 
         # Cycle through each feature checking in bounds and getting geometry and properties
         features = {'geometry': []}
@@ -100,6 +131,63 @@ class Linz:
                 # Add the value of each property in turn
                 for key in feature['properties'].keys():
                     features[key].append(feature['properties'][key])
+
+        # Convert to a geopandas dataframe
+        if len(features) > 0:
+            features = geopandas.GeoDataFrame(features, crs=self.catchment_polygon.crs)
+        else:
+            features = None
+
+        return features
+
+
+    def query_vector_wfs(self, bounds, layer: int, geometry_type: str):
+        """ Function to check for all features associated with a layer using the LINZ WFS vector query API
+        https://www.linz.govt.nz/data/linz-data-service/guides-and-documentation/wfs-spatial-filtering """
+
+        data_url = urllib.parse.urlunparse((self.SCHEME, self.NETLOC_API,
+                                            f"{self.WFS_PATH_API_START}{self.key}{self.WFS_PATH_API_END}",
+                                            "", "", ""))
+
+        api_query = {
+            "service": "WFS",
+            "version": 2.0,
+            "request": "GetFeature",
+            "typeNames": f"layer-{layer}",
+            "outputFormat": "json",
+            "SRSName": f"{self.catchment_polygon.crs.to_string()}"
+        }
+
+        response = requests.get(data_url, params=api_query, stream=True)
+
+        response.raise_for_status()
+        return response.json()
+
+    def get_features(self, layer: int):
+        """ Get a list of all features associated with layer """
+
+        # radius in metres
+        feature_collection = self.query_vector_wfs(layer)
+
+        # Cycle through each feature checking in bounds and getting geometry and properties
+        features = {'geometry': []}
+        for feature in feature_collection['features']:
+
+            shapely_geometry = shapely.geometry.shape(feature['geometry'])
+
+            # Create column headings for each 'properties' option from the first in-bounds vector
+            if len(features['geometry']) == 0:
+                for key in feature['properties'].keys():
+                    features[key] = []  # The empty list to append the property values too
+
+            # Convert any one Polygon MultiPolygon to a straight Polygon then add to the geometries
+            if (shapely_geometry.geometryType() == 'MultiPolygon' and len(shapely_geometry) == 1):
+                shapely_geometry = shapely_geometry[0]
+            features['geometry'].append(shapely_geometry)
+
+            # Add the value of each property in turn
+            for key in feature['properties'].keys():
+                features[key].append(feature['properties'][key])
 
         # Convert to a geopandas dataframe
         if len(features) > 0:

--- a/tests/test_vector/instruction.json
+++ b/tests/test_vector/instruction.json
@@ -6,13 +6,11 @@
     },
 	"apis": {
 		"linz": {
-			"land": {
-				"layers": [51153],
-				"geometry_name": "GEOMETRY"
+			"railways": {
+				"layers": [50781]
 			},
-			"bathymetry_contours": {
-				"layers": [50448],
-				"geometry_name": "shape"
+			"pastural_lease": {
+				"layers": [51572]
 			}
 		}
 	}

--- a/tests/test_vector/instruction.json
+++ b/tests/test_vector/instruction.json
@@ -8,11 +8,11 @@
 		"linz": {
 			"land": {
 				"layers": [51153],
-				"type": "GEOMETRY"
+				"geometry_name": "GEOMETRY"
 			},
 			"bathymetry_contours": {
 				"layers": [50448],
-				"type": "shape"
+				"geometry_name": "shape"
 			}
 		}
 	}

--- a/tests/test_vector/test_vector.py
+++ b/tests/test_vector/test_vector.py
@@ -55,7 +55,8 @@ class LinzVectorsTest(unittest.TestCase):
 
         # Run pipeline - download files
         cls.runner = vector.Linz(cls.instructions['instructions']['apis']['linz']['key'],
-                                 catchment_polygon=None, verbose=True)
+                                 crs = cls.instructions['instructions']['projection'], catchment_polygon=None,
+                                 verbose=True)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_vector/test_vector.py
+++ b/tests/test_vector/test_vector.py
@@ -93,7 +93,7 @@ class LinzVectorsTest(unittest.TestCase):
         """ A test to check expected island is loaded """
 
         land = self.runner.run(self.instructions['instructions']['apis']['linz']['land']['layers'][0],
-                               self.instructions['instructions']['apis']['linz']['land']['type'])
+                               self.instructions['instructions']['apis']['linz']['land']['geometry_name'])
 
         # check various shape attributes match those expected
         self.assertEqual(land.loc[0].geometry.geometryType(), self.LAND['geometryType'], "The geometryType of the " +
@@ -108,12 +108,57 @@ class LinzVectorsTest(unittest.TestCase):
         self.assertEqual(land.geometry.length.sum(), self.LAND['length'], "The length of the returned land polygon " +
                          f"`{land.geometry.length.sum()}` differs from the expected {self.LAND['length']}")
 
+
+    def test_land_no_geometry_name(self):
+        """ A test to check expected island is loaded """
+
+        land = self.runner.run(self.instructions['instructions']['apis']['linz']['land']['layers'][0])
+
+        # check various shape attributes match those expected
+        self.assertEqual(land.loc[0].geometry.geometryType(), self.LAND['geometryType'], "The geometryType of the " +
+                         f"returned land polygon `{land.loc[0].geometry.geometryType()}` differs from the expected " +
+                         f"{self.LAND['geometryType']}")
+        self.assertEqual(list(land.columns), self.LAND['columns'], "The columns of the returned land polygon " +
+                         f"`{list(land.columns)}` differ from the expected {self.LAND['columns']}")
+        self.assertEqual(list(land['name_ascii']), self.LAND['name'], "The value of the land polygon's 'name' column " +
+                         f"`{list(land['name_ascii'])}` differ from the expected {self.LAND['name']}")
+        self.assertEqual(land.geometry.area.sum(), self.LAND['area'], "The area of the returned land polygon " +
+                         f"`{land.geometry.area.sum()}` differs from the expected {self.LAND['area']}")
+        self.assertEqual(land.geometry.length.sum(), self.LAND['length'], "The length of the returned land polygon " +
+                         f"`{land.geometry.length.sum()}` differs from the expected {self.LAND['length']}")
+
+
     def test_bathymetry(self):
         """ A test to check expected bathyemtry contours are loaded """
 
         bathymetry_contours = self.runner.run(
             self.instructions['instructions']['apis']['linz']['bathymetry_contours']['layers'][0],
-            self.instructions['instructions']['apis']['linz']['bathymetry_contours']['type'])
+            self.instructions['instructions']['apis']['linz']['bathymetry_contours']['geometry_name'])
+
+        # check various shape attributes match those expected
+        self.assertEqual(bathymetry_contours.loc[0].geometry.geometryType(), self.BATHYMETRY_CONTOURS['geometryType'],
+                         "The geometryType of the returned land polygon " +
+                         f"`{bathymetry_contours.loc[0].geometry.geometryType()}` differs from the expected " +
+                         f"{self.BATHYMETRY_CONTOURS['geometryType']}")
+        self.assertEqual(list(bathymetry_contours.columns), self.BATHYMETRY_CONTOURS['columns'], "The columns of the" +
+                         f" returned land polygon `{list(bathymetry_contours.columns)}` differ from the expected " +
+                         f"{self.BATHYMETRY_CONTOURS['columns']}")
+        self.assertEqual(list(bathymetry_contours['valdco']), self.BATHYMETRY_CONTOURS['valdco'], "The columns of the" +
+                         f" land polygon's 'valdco' column `{list(bathymetry_contours['valdco'])}` differ from the " +
+                         f"expected {self.BATHYMETRY_CONTOURS['valdco']}")
+        self.assertEqual(bathymetry_contours.geometry.area.sum(), self.BATHYMETRY_CONTOURS['area'], "The area of the " +
+                         f"returned bathymetry_contours polygon `{bathymetry_contours.geometry.area.sum()}` differs " +
+                         "from the expected {self.BATHYMETRY_CONTOURS['area']}")
+        self.assertEqual(bathymetry_contours.geometry.length.sum(), self.BATHYMETRY_CONTOURS['length'], "The area of " +
+                         f"the returned bathymetry_contours polygon `{bathymetry_contours.geometry.length.sum()}` " +
+                         "differs from the expected {self.BATHYMETRY_CONTOURS['length']}")
+
+
+    def test_bathymetry_no_geometry_name(self):
+        """ A test to check expected bathyemtry contours are loaded """
+
+        bathymetry_contours = self.runner.run(
+            self.instructions['instructions']['apis']['linz']['bathymetry_contours']['layers'][0])
 
         # check various shape attributes match those expected
         self.assertEqual(bathymetry_contours.loc[0].geometry.geometryType(), self.BATHYMETRY_CONTOURS['geometryType'],

--- a/tests/test_vector/test_vector.py
+++ b/tests/test_vector/test_vector.py
@@ -55,7 +55,7 @@ class LinzVectorsTest(unittest.TestCase):
 
         # Run pipeline - download files
         cls.runner = vector.Linz(cls.instructions['instructions']['apis']['linz']['key'],
-                                 crs = cls.instructions['instructions']['projection'], catchment_polygon=None,
+                                 crs=cls.instructions['instructions']['projection'], catchment_polygon=None,
                                  verbose=True)
 
     @classmethod
@@ -91,7 +91,7 @@ class LinzVectorsTest(unittest.TestCase):
         features = self.runner.run(self.instructions['instructions']['apis']['linz']['pastural_lease']['layers'][0])
         description = "pastural lease parcels"
         benchmark = self.PASTURAL_LEASE
-        
+
         # check various shape attributes match those expected
         self.assertEqual(features.loc[0].geometry.geometryType(), benchmark['geometryType'], "The geometryType of the" +
                          f" returned {description} `{features.loc[0].geometry.geometryType()}` differs from the " +
@@ -104,7 +104,6 @@ class LinzVectorsTest(unittest.TestCase):
                          f"`{features.geometry.area.sum()}` differs from the expected {benchmark['area']}")
         self.assertEqual(features.geometry.length.sum(), benchmark['length'], "The length of the returned {description}"
                          + f"`{features.geometry.length.sum()}` differs from the expected {benchmark['length']}")
-
 
 
 if __name__ == '__main__':

--- a/tests/test_vector/test_vector.py
+++ b/tests/test_vector/test_vector.py
@@ -36,7 +36,7 @@ class LinzVectorsTest(unittest.TestCase):
         in the tests. """
 
         # load in the test instructions
-        file_path = pathlib.Path().cwd() / pathlib.Path("tests/test_vector_in_bounds/instruction.json")
+        file_path = pathlib.Path().cwd() / pathlib.Path("tests/test_vector/instruction.json")
         with open(file_path, 'r') as file_pointer:
             cls.instructions = json.load(file_pointer)
 

--- a/tests/test_vector/test_vector.py
+++ b/tests/test_vector/test_vector.py
@@ -8,8 +8,6 @@ Created on Wed Jun 30 11:11:25 2021
 import unittest
 import json
 import pathlib
-import shapely
-import geopandas
 import shutil
 import dotenv
 import os
@@ -22,18 +20,15 @@ class LinzVectorsTest(unittest.TestCase):
     OpenTopography within a small region. All files are deleted after checking their names and size.
 
     Tests run include:
-        1. test_land - Test that the expected land dataset is downloaded from LINZ
-        2. test_bathymetry - Test that the expected land dataset is downloaded from LINZ
+        1. test_railways - Test that the expected railways dataset is downloaded from LINZ
+        2. test_pastural_lease - Test that the expected pastural lease dataset is downloaded from LINZ
     """
 
     # The expected datasets and files to be downloaded - used for comparison in the later tests
-    LAND = {"area": 150539169542.3913, "geometryType": 'Polygon', 'length': 6006036.039821965,
-            'columns': ['geometry', 'name', 'macronated', 'grp_macron', 'TARGET_FID', 'grp_ascii', 'grp_name',
-                        'name_ascii'], 'name': ['South Island or Te Waipounamu']}
-    BATHYMETRY_CONTOURS = {"area": 0.0, "geometryType": 'LineString', 'length': 144353.73387463146,
-                           'columns': ['geometry', 'fidn', 'valdco', 'verdat', 'inform', 'ninfom', 'ntxtds',
-                                       'scamin', 'txtdsc', 'sordat', 'sorind', 'hypcat'],
-                           'valdco': [2.0, 2.0, 0.0, 0.0, 0.0, 0.0, 20.0, 0.0, 0.0, 5.0, 10.0, 30.0, 2.0, 0.0]}
+    RAILWAYS = {"area": 0.0, "geometryType": 'MultiLineString', 'length': 5475052.898111259,
+                'columns': ['geometry', 'id', 'name', 'name_utf8'], 'id': [1775717, 1775718, 1775719, 1778938, 1778939]}
+    PASTURAL_LEASE = {"area": 13387663696.368122, "geometryType": 'POLYGON ', 'length': 15756644.418670136,
+                      'columns': ['geometry', 'id', 'lease_name'], 'id': [12767, 12768, 12770, 12773, 12776]}
 
     @classmethod
     def setUpClass(cls):
@@ -41,7 +36,7 @@ class LinzVectorsTest(unittest.TestCase):
         in the tests. """
 
         # load in the test instructions
-        file_path = pathlib.Path().cwd() / pathlib.Path("tests/test_vector/instruction.json")
+        file_path = pathlib.Path().cwd() / pathlib.Path("tests/test_vector_in_bounds/instruction.json")
         with open(file_path, 'r') as file_pointer:
             cls.instructions = json.load(file_pointer)
 
@@ -58,29 +53,9 @@ class LinzVectorsTest(unittest.TestCase):
             shutil.rmtree(cls.cache_dir)
         cls.cache_dir.mkdir()
 
-        # create fake catchment boundary
-        x0 = 1477354
-        x1 = 1484656
-        y0 = 5374408
-        y1 = 5383411
-        catchment = shapely.geometry.Polygon([(x0, y0), (x0, y1), (x1, y1), (x1, y0)])
-        catchment = geopandas.GeoSeries([catchment])
-        catchment = catchment.set_crs(cls.instructions['instructions']['projection'])
-
-        # save faked catchment file
-        catchment_dir = cls.cache_dir / "catchment"
-        catchment.to_file(catchment_dir)
-        shutil.make_archive(base_name=catchment_dir, format='zip', root_dir=catchment_dir)
-        shutil.rmtree(catchment_dir)
-
-        # cconvert catchment file to zipfile
-        catchment_dir = pathlib.Path(str(catchment_dir) + ".zip")
-        catchment_polygon = geopandas.read_file(catchment_dir)
-        catchment_polygon.to_crs(cls.instructions['instructions']['projection'])
-
         # Run pipeline - download files
         cls.runner = vector.Linz(cls.instructions['instructions']['apis']['linz']['key'],
-                                 catchment_polygon, verbose=True)
+                                 catchment_polygon=None, verbose=True)
 
     @classmethod
     def tearDownClass(cls):
@@ -89,94 +64,46 @@ class LinzVectorsTest(unittest.TestCase):
         if cls.cache_dir.exists():
             shutil.rmtree(cls.cache_dir)
 
-    def test_land(self):
+    def test_railways(self):
         """ A test to check expected island is loaded """
 
-        land = self.runner.run(self.instructions['instructions']['apis']['linz']['land']['layers'][0],
-                               self.instructions['instructions']['apis']['linz']['land']['geometry_name'])
+        features = self.runner.run(self.instructions['instructions']['apis']['linz']['railways']['layers'][0])
+        description = "railways centre lines"
+        benchmark = self.RAILWAYS
 
         # check various shape attributes match those expected
-        self.assertEqual(land.loc[0].geometry.geometryType(), self.LAND['geometryType'], "The geometryType of the " +
-                         f"returned land polygon `{land.loc[0].geometry.geometryType()}` differs from the expected " +
-                         f"{self.LAND['geometryType']}")
-        self.assertEqual(list(land.columns), self.LAND['columns'], "The columns of the returned land polygon " +
-                         f"`{list(land.columns)}` differ from the expected {self.LAND['columns']}")
-        self.assertEqual(list(land['name_ascii']), self.LAND['name'], "The value of the land polygon's 'name' column " +
-                         f"`{list(land['name_ascii'])}` differ from the expected {self.LAND['name']}")
-        self.assertEqual(land.geometry.area.sum(), self.LAND['area'], "The area of the returned land polygon " +
-                         f"`{land.geometry.area.sum()}` differs from the expected {self.LAND['area']}")
-        self.assertEqual(land.geometry.length.sum(), self.LAND['length'], "The length of the returned land polygon " +
-                         f"`{land.geometry.length.sum()}` differs from the expected {self.LAND['length']}")
+        self.assertEqual(features.loc[0].geometry.geometryType(), benchmark['geometryType'], "The geometryType of the" +
+                         f" returned {description} `{features.loc[0].geometry.geometryType()}` differs from the " +
+                         f"expected {benchmark['geometryType']}")
+        self.assertEqual(list(features.columns), benchmark['columns'], "The columns of the returned {description}" +
+                         f" lines `{list(features.columns)}` differ from the expected {benchmark['columns']}")
+        self.assertEqual(list(features['id'][0:5]), benchmark['id'], "The value of the 'id' column for the first" +
+                         f" five entries `{list(features['id'][0:5])}` differ from the expected {benchmark['id']}")
+        self.assertEqual(features.geometry.area.sum(), benchmark['area'], "The area of the returned {description}" +
+                         f"`{features.geometry.area.sum()}` differs from the expected {benchmark['area']}")
+        self.assertEqual(features.geometry.length.sum(), benchmark['length'], "The length of the returned {description}"
+                         + f"`{features.geometry.length.sum()}` differs from the expected {benchmark['length']}")
 
-
-    def test_land_no_geometry_name(self):
+    def test_pastural_lease(self):
         """ A test to check expected island is loaded """
 
-        land = self.runner.run(self.instructions['instructions']['apis']['linz']['land']['layers'][0])
-
+        features = self.runner.run(self.instructions['instructions']['apis']['linz']['pastural_lease']['layers'][0])
+        description = "railways centre lines"
+        benchmark = self.PASTURAL_LEASE
+        
         # check various shape attributes match those expected
-        self.assertEqual(land.loc[0].geometry.geometryType(), self.LAND['geometryType'], "The geometryType of the " +
-                         f"returned land polygon `{land.loc[0].geometry.geometryType()}` differs from the expected " +
-                         f"{self.LAND['geometryType']}")
-        self.assertEqual(list(land.columns), self.LAND['columns'], "The columns of the returned land polygon " +
-                         f"`{list(land.columns)}` differ from the expected {self.LAND['columns']}")
-        self.assertEqual(list(land['name_ascii']), self.LAND['name'], "The value of the land polygon's 'name' column " +
-                         f"`{list(land['name_ascii'])}` differ from the expected {self.LAND['name']}")
-        self.assertEqual(land.geometry.area.sum(), self.LAND['area'], "The area of the returned land polygon " +
-                         f"`{land.geometry.area.sum()}` differs from the expected {self.LAND['area']}")
-        self.assertEqual(land.geometry.length.sum(), self.LAND['length'], "The length of the returned land polygon " +
-                         f"`{land.geometry.length.sum()}` differs from the expected {self.LAND['length']}")
+        self.assertEqual(features.loc[0].geometry.geometryType(), benchmark['geometryType'], "The geometryType of the" +
+                         f" returned {description} `{features.loc[0].geometry.geometryType()}` differs from the " +
+                         f"expected {benchmark['geometryType']}")
+        self.assertEqual(list(features.columns), benchmark['columns'], "The columns of the returned {description}" +
+                         f" lines `{list(features.columns)}` differ from the expected {benchmark['columns']}")
+        self.assertEqual(list(features['id'][0:5]), benchmark['id'], "The value of the 'id' column for the first" +
+                         f" five entries `{list(features['id'][0:5])}` differ from the expected {benchmark['id']}")
+        self.assertEqual(features.geometry.area.sum(), benchmark['area'], "The area of the returned {description}" +
+                         f"`{features.geometry.area.sum()}` differs from the expected {benchmark['area']}")
+        self.assertEqual(features.geometry.length.sum(), benchmark['length'], "The length of the returned {description}"
+                         + f"`{features.geometry.length.sum()}` differs from the expected {benchmark['length']}")
 
-
-    def test_bathymetry(self):
-        """ A test to check expected bathyemtry contours are loaded """
-
-        bathymetry_contours = self.runner.run(
-            self.instructions['instructions']['apis']['linz']['bathymetry_contours']['layers'][0],
-            self.instructions['instructions']['apis']['linz']['bathymetry_contours']['geometry_name'])
-
-        # check various shape attributes match those expected
-        self.assertEqual(bathymetry_contours.loc[0].geometry.geometryType(), self.BATHYMETRY_CONTOURS['geometryType'],
-                         "The geometryType of the returned land polygon " +
-                         f"`{bathymetry_contours.loc[0].geometry.geometryType()}` differs from the expected " +
-                         f"{self.BATHYMETRY_CONTOURS['geometryType']}")
-        self.assertEqual(list(bathymetry_contours.columns), self.BATHYMETRY_CONTOURS['columns'], "The columns of the" +
-                         f" returned land polygon `{list(bathymetry_contours.columns)}` differ from the expected " +
-                         f"{self.BATHYMETRY_CONTOURS['columns']}")
-        self.assertEqual(list(bathymetry_contours['valdco']), self.BATHYMETRY_CONTOURS['valdco'], "The columns of the" +
-                         f" land polygon's 'valdco' column `{list(bathymetry_contours['valdco'])}` differ from the " +
-                         f"expected {self.BATHYMETRY_CONTOURS['valdco']}")
-        self.assertEqual(bathymetry_contours.geometry.area.sum(), self.BATHYMETRY_CONTOURS['area'], "The area of the " +
-                         f"returned bathymetry_contours polygon `{bathymetry_contours.geometry.area.sum()}` differs " +
-                         "from the expected {self.BATHYMETRY_CONTOURS['area']}")
-        self.assertEqual(bathymetry_contours.geometry.length.sum(), self.BATHYMETRY_CONTOURS['length'], "The area of " +
-                         f"the returned bathymetry_contours polygon `{bathymetry_contours.geometry.length.sum()}` " +
-                         "differs from the expected {self.BATHYMETRY_CONTOURS['length']}")
-
-
-    def test_bathymetry_no_geometry_name(self):
-        """ A test to check expected bathyemtry contours are loaded """
-
-        bathymetry_contours = self.runner.run(
-            self.instructions['instructions']['apis']['linz']['bathymetry_contours']['layers'][0])
-
-        # check various shape attributes match those expected
-        self.assertEqual(bathymetry_contours.loc[0].geometry.geometryType(), self.BATHYMETRY_CONTOURS['geometryType'],
-                         "The geometryType of the returned land polygon " +
-                         f"`{bathymetry_contours.loc[0].geometry.geometryType()}` differs from the expected " +
-                         f"{self.BATHYMETRY_CONTOURS['geometryType']}")
-        self.assertEqual(list(bathymetry_contours.columns), self.BATHYMETRY_CONTOURS['columns'], "The columns of the" +
-                         f" returned land polygon `{list(bathymetry_contours.columns)}` differ from the expected " +
-                         f"{self.BATHYMETRY_CONTOURS['columns']}")
-        self.assertEqual(list(bathymetry_contours['valdco']), self.BATHYMETRY_CONTOURS['valdco'], "The columns of the" +
-                         f" land polygon's 'valdco' column `{list(bathymetry_contours['valdco'])}` differ from the " +
-                         f"expected {self.BATHYMETRY_CONTOURS['valdco']}")
-        self.assertEqual(bathymetry_contours.geometry.area.sum(), self.BATHYMETRY_CONTOURS['area'], "The area of the " +
-                         f"returned bathymetry_contours polygon `{bathymetry_contours.geometry.area.sum()}` differs " +
-                         "from the expected {self.BATHYMETRY_CONTOURS['area']}")
-        self.assertEqual(bathymetry_contours.geometry.length.sum(), self.BATHYMETRY_CONTOURS['length'], "The area of " +
-                         f"the returned bathymetry_contours polygon `{bathymetry_contours.geometry.length.sum()}` " +
-                         "differs from the expected {self.BATHYMETRY_CONTOURS['length']}")
 
 
 if __name__ == '__main__':

--- a/tests/test_vector/test_vector.py
+++ b/tests/test_vector/test_vector.py
@@ -27,7 +27,7 @@ class LinzVectorsTest(unittest.TestCase):
     # The expected datasets and files to be downloaded - used for comparison in the later tests
     RAILWAYS = {"area": 0.0, "geometryType": 'MultiLineString', 'length': 5475052.898111259,
                 'columns': ['geometry', 'id', 'name', 'name_utf8'], 'id': [1775717, 1775718, 1775719, 1778938, 1778939]}
-    PASTURAL_LEASE = {"area": 13387663696.368122, "geometryType": 'POLYGON ', 'length': 15756644.418670136,
+    PASTURAL_LEASE = {"area": 13387663696.368122, "geometryType": 'MultiPolygon', 'length': 15756644.418670136,
                       'columns': ['geometry', 'id', 'lease_name'], 'id': [12767, 12768, 12770, 12773, 12776]}
 
     @classmethod
@@ -89,7 +89,7 @@ class LinzVectorsTest(unittest.TestCase):
         """ A test to check expected island is loaded """
 
         features = self.runner.run(self.instructions['instructions']['apis']['linz']['pastural_lease']['layers'][0])
-        description = "railways centre lines"
+        description = "pastural lease parcels"
         benchmark = self.PASTURAL_LEASE
         
         # check various shape attributes match those expected

--- a/tests/test_vector/test_vector.py
+++ b/tests/test_vector/test_vector.py
@@ -55,7 +55,7 @@ class LinzVectorsTest(unittest.TestCase):
 
         # Run pipeline - download files
         cls.runner = vector.Linz(cls.instructions['instructions']['apis']['linz']['key'],
-                                 crs=cls.instructions['instructions']['projection'], catchment_polygon=None,
+                                 crs=cls.instructions['instructions']['projection'], bounding_polygon=None,
                                  verbose=True)
 
     @classmethod

--- a/tests/test_vector_in_bounds/__init__.py
+++ b/tests/test_vector_in_bounds/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Jun 29 14:33:10 2021
+
+@author: pearsonra
+"""

--- a/tests/test_vector_in_bounds/instruction.json
+++ b/tests/test_vector_in_bounds/instruction.json
@@ -1,0 +1,20 @@
+{"instructions": 
+  {
+    "projection": 2193,
+    "data_paths": {
+      "local_cache": "tests/test_vector_in_bounds/data"
+    },
+	"apis": {
+		"linz": {
+			"land": {
+				"layers": [51153],
+				"geometry_name": "GEOMETRY"
+			},
+			"bathymetry_contours": {
+				"layers": [50448],
+				"geometry_name": "shape"
+			}
+		}
+	}
+  }
+}

--- a/tests/test_vector_in_bounds/test_vector_in_bounds.py
+++ b/tests/test_vector_in_bounds/test_vector_in_bounds.py
@@ -79,7 +79,7 @@ class LinzVectorsTest(unittest.TestCase):
 
         # Run pipeline - download files
         cls.runner = vector.Linz(cls.instructions['instructions']['apis']['linz']['key'], crs=None,
-                                 catchment_polygon=catchment_polygon, verbose=True)
+                                 bounding_polygon=catchment_polygon, verbose=True)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_vector_in_bounds/test_vector_in_bounds.py
+++ b/tests/test_vector_in_bounds/test_vector_in_bounds.py
@@ -76,11 +76,10 @@ class LinzVectorsTest(unittest.TestCase):
         # cconvert catchment file to zipfile
         catchment_dir = pathlib.Path(str(catchment_dir) + ".zip")
         catchment_polygon = geopandas.read_file(catchment_dir)
-        catchment_polygon.to_crs(cls.instructions['instructions']['projection'])
 
         # Run pipeline - download files
-        cls.runner = vector.Linz(cls.instructions['instructions']['apis']['linz']['key'],
-                                 catchment_polygon, verbose=True)
+        cls.runner = vector.Linz(cls.instructions['instructions']['apis']['linz']['key'], crs=None,
+                                 catchment_polygon=catchment_polygon, verbose=True)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_vector_in_bounds/test_vector_in_bounds.py
+++ b/tests/test_vector_in_bounds/test_vector_in_bounds.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Jun 30 11:11:25 2021
+
+@author: pearsonra
+"""
+
+import unittest
+import json
+import pathlib
+import shapely
+import geopandas
+import shutil
+import dotenv
+import os
+
+from src.geoapis import vector
+
+
+class LinzVectorsTest(unittest.TestCase):
+    """ A class to test the basic vector.Linz functionality by downloading files from
+    OpenTopography within a small region. All files are deleted after checking their names and size.
+
+    Tests run include:
+        1. test_land - Test that the expected land dataset is downloaded from LINZ
+        2. test_bathymetry - Test that the expected bathymetry dataset is downloaded from LINZ
+    """
+
+    # The expected datasets and files to be downloaded - used for comparison in the later tests
+    LAND = {"area": 150539169542.3913, "geometryType": 'Polygon', 'length': 6006036.039821965,
+            'columns': ['geometry', 'name', 'macronated', 'grp_macron', 'TARGET_FID', 'grp_ascii', 'grp_name',
+                        'name_ascii'], 'name': ['South Island or Te Waipounamu']}
+    BATHYMETRY_CONTOURS = {"area": 0.0, "geometryType": 'LineString', 'length': 144353.73387463146,
+                           'columns': ['geometry', 'fidn', 'valdco', 'verdat', 'inform', 'ninfom', 'ntxtds',
+                                       'scamin', 'txtdsc', 'sordat', 'sorind', 'hypcat'],
+                           'valdco': [2.0, 2.0, 0.0, 0.0, 0.0, 0.0, 20.0, 0.0, 0.0, 5.0, 10.0, 30.0, 2.0, 0.0]}
+
+    @classmethod
+    def setUpClass(cls):
+        """ Create a cache directory and CatchmentGeometry object for use in the tests and also download the files used
+        in the tests. """
+
+        # load in the test instructions
+        file_path = pathlib.Path().cwd() / pathlib.Path("tests/test_vector_in_bounds/instruction.json")
+        with open(file_path, 'r') as file_pointer:
+            cls.instructions = json.load(file_pointer)
+
+        # Load in environment variables to get and set the private API keys
+        dotenv.load_dotenv()
+        linz_key = os.environ.get('LINZ_API', None)
+        cls.instructions['instructions']['apis']['linz']['key'] = linz_key
+
+        # define cache location - and catchment dirs
+        cls.cache_dir = pathlib.Path(cls.instructions['instructions']['data_paths']['local_cache'])
+
+        # makes sure the data directory exists but is empty
+        if cls.cache_dir.exists():
+            shutil.rmtree(cls.cache_dir)
+        cls.cache_dir.mkdir()
+
+        # create fake catchment boundary
+        x0 = 1477354
+        x1 = 1484656
+        y0 = 5374408
+        y1 = 5383411
+        catchment = shapely.geometry.Polygon([(x0, y0), (x0, y1), (x1, y1), (x1, y0)])
+        catchment = geopandas.GeoSeries([catchment])
+        catchment = catchment.set_crs(cls.instructions['instructions']['projection'])
+
+        # save faked catchment file
+        catchment_dir = cls.cache_dir / "catchment"
+        catchment.to_file(catchment_dir)
+        shutil.make_archive(base_name=catchment_dir, format='zip', root_dir=catchment_dir)
+        shutil.rmtree(catchment_dir)
+
+        # cconvert catchment file to zipfile
+        catchment_dir = pathlib.Path(str(catchment_dir) + ".zip")
+        catchment_polygon = geopandas.read_file(catchment_dir)
+        catchment_polygon.to_crs(cls.instructions['instructions']['projection'])
+
+        # Run pipeline - download files
+        cls.runner = vector.Linz(cls.instructions['instructions']['apis']['linz']['key'],
+                                 catchment_polygon, verbose=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        """ Remove created cache directory. """
+
+        if cls.cache_dir.exists():
+            shutil.rmtree(cls.cache_dir)
+
+    def test_land(self):
+        """ A test to check expected island is loaded """
+
+        land = self.runner.run(self.instructions['instructions']['apis']['linz']['land']['layers'][0],
+                               self.instructions['instructions']['apis']['linz']['land']['geometry_name'])
+
+        # check various shape attributes match those expected
+        self.assertEqual(land.loc[0].geometry.geometryType(), self.LAND['geometryType'], "The geometryType of the " +
+                         f"returned land polygon `{land.loc[0].geometry.geometryType()}` differs from the expected " +
+                         f"{self.LAND['geometryType']}")
+        self.assertEqual(list(land.columns), self.LAND['columns'], "The columns of the returned land polygon " +
+                         f"`{list(land.columns)}` differ from the expected {self.LAND['columns']}")
+        self.assertEqual(list(land['name_ascii']), self.LAND['name'], "The value of the land polygon's 'name' column " +
+                         f"`{list(land['name_ascii'])}` differ from the expected {self.LAND['name']}")
+        self.assertEqual(land.geometry.area.sum(), self.LAND['area'], "The area of the returned land polygon " +
+                         f"`{land.geometry.area.sum()}` differs from the expected {self.LAND['area']}")
+        self.assertEqual(land.geometry.length.sum(), self.LAND['length'], "The length of the returned land polygon " +
+                         f"`{land.geometry.length.sum()}` differs from the expected {self.LAND['length']}")
+
+
+    def test_land_no_geometry_name(self):
+        """ A test to check expected island is loaded """
+
+        land = self.runner.run(self.instructions['instructions']['apis']['linz']['land']['layers'][0])
+
+        # check various shape attributes match those expected
+        self.assertEqual(land.loc[0].geometry.geometryType(), self.LAND['geometryType'], "The geometryType of the " +
+                         f"returned land polygon `{land.loc[0].geometry.geometryType()}` differs from the expected " +
+                         f"{self.LAND['geometryType']}")
+        self.assertEqual(list(land.columns), self.LAND['columns'], "The columns of the returned land polygon " +
+                         f"`{list(land.columns)}` differ from the expected {self.LAND['columns']}")
+        self.assertEqual(list(land['name_ascii']), self.LAND['name'], "The value of the land polygon's 'name' column " +
+                         f"`{list(land['name_ascii'])}` differ from the expected {self.LAND['name']}")
+        self.assertEqual(land.geometry.area.sum(), self.LAND['area'], "The area of the returned land polygon " +
+                         f"`{land.geometry.area.sum()}` differs from the expected {self.LAND['area']}")
+        self.assertEqual(land.geometry.length.sum(), self.LAND['length'], "The length of the returned land polygon " +
+                         f"`{land.geometry.length.sum()}` differs from the expected {self.LAND['length']}")
+
+
+    def test_bathymetry(self):
+        """ A test to check expected bathyemtry contours are loaded """
+
+        bathymetry_contours = self.runner.run(
+            self.instructions['instructions']['apis']['linz']['bathymetry_contours']['layers'][0],
+            self.instructions['instructions']['apis']['linz']['bathymetry_contours']['geometry_name'])
+
+        # check various shape attributes match those expected
+        self.assertEqual(bathymetry_contours.loc[0].geometry.geometryType(), self.BATHYMETRY_CONTOURS['geometryType'],
+                         "The geometryType of the returned land polygon " +
+                         f"`{bathymetry_contours.loc[0].geometry.geometryType()}` differs from the expected " +
+                         f"{self.BATHYMETRY_CONTOURS['geometryType']}")
+        self.assertEqual(list(bathymetry_contours.columns), self.BATHYMETRY_CONTOURS['columns'], "The columns of the" +
+                         f" returned land polygon `{list(bathymetry_contours.columns)}` differ from the expected " +
+                         f"{self.BATHYMETRY_CONTOURS['columns']}")
+        self.assertEqual(list(bathymetry_contours['valdco']), self.BATHYMETRY_CONTOURS['valdco'], "The columns of the" +
+                         f" land polygon's 'valdco' column `{list(bathymetry_contours['valdco'])}` differ from the " +
+                         f"expected {self.BATHYMETRY_CONTOURS['valdco']}")
+        self.assertEqual(bathymetry_contours.geometry.area.sum(), self.BATHYMETRY_CONTOURS['area'], "The area of the " +
+                         f"returned bathymetry_contours polygon `{bathymetry_contours.geometry.area.sum()}` differs " +
+                         "from the expected {self.BATHYMETRY_CONTOURS['area']}")
+        self.assertEqual(bathymetry_contours.geometry.length.sum(), self.BATHYMETRY_CONTOURS['length'], "The area of " +
+                         f"the returned bathymetry_contours polygon `{bathymetry_contours.geometry.length.sum()}` " +
+                         "differs from the expected {self.BATHYMETRY_CONTOURS['length']}")
+
+
+    def test_bathymetry_no_geometry_name(self):
+        """ A test to check expected bathyemtry contours are loaded """
+
+        bathymetry_contours = self.runner.run(
+            self.instructions['instructions']['apis']['linz']['bathymetry_contours']['layers'][0])
+
+        # check various shape attributes match those expected
+        self.assertEqual(bathymetry_contours.loc[0].geometry.geometryType(), self.BATHYMETRY_CONTOURS['geometryType'],
+                         "The geometryType of the returned land polygon " +
+                         f"`{bathymetry_contours.loc[0].geometry.geometryType()}` differs from the expected " +
+                         f"{self.BATHYMETRY_CONTOURS['geometryType']}")
+        self.assertEqual(list(bathymetry_contours.columns), self.BATHYMETRY_CONTOURS['columns'], "The columns of the" +
+                         f" returned land polygon `{list(bathymetry_contours.columns)}` differ from the expected " +
+                         f"{self.BATHYMETRY_CONTOURS['columns']}")
+        self.assertEqual(list(bathymetry_contours['valdco']), self.BATHYMETRY_CONTOURS['valdco'], "The columns of the" +
+                         f" land polygon's 'valdco' column `{list(bathymetry_contours['valdco'])}` differ from the " +
+                         f"expected {self.BATHYMETRY_CONTOURS['valdco']}")
+        self.assertEqual(bathymetry_contours.geometry.area.sum(), self.BATHYMETRY_CONTOURS['area'], "The area of the " +
+                         f"returned bathymetry_contours polygon `{bathymetry_contours.geometry.area.sum()}` differs " +
+                         "from the expected {self.BATHYMETRY_CONTOURS['area']}")
+        self.assertEqual(bathymetry_contours.geometry.length.sum(), self.BATHYMETRY_CONTOURS['length'], "The area of " +
+                         f"the returned bathymetry_contours polygon `{bathymetry_contours.geometry.length.sum()}` " +
+                         "differs from the expected {self.BATHYMETRY_CONTOURS['length']}")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_vector_in_bounds/test_vector_in_bounds.py
+++ b/tests/test_vector_in_bounds/test_vector_in_bounds.py
@@ -107,7 +107,6 @@ class LinzVectorsTest(unittest.TestCase):
         self.assertEqual(land.geometry.length.sum(), self.LAND['length'], "The length of the returned land polygon " +
                          f"`{land.geometry.length.sum()}` differs from the expected {self.LAND['length']}")
 
-
     def test_land_no_geometry_name(self):
         """ A test to check expected island is loaded """
 
@@ -125,7 +124,6 @@ class LinzVectorsTest(unittest.TestCase):
                          f"`{land.geometry.area.sum()}` differs from the expected {self.LAND['area']}")
         self.assertEqual(land.geometry.length.sum(), self.LAND['length'], "The length of the returned land polygon " +
                          f"`{land.geometry.length.sum()}` differs from the expected {self.LAND['length']}")
-
 
     def test_bathymetry(self):
         """ A test to check expected bathyemtry contours are loaded """
@@ -151,7 +149,6 @@ class LinzVectorsTest(unittest.TestCase):
         self.assertEqual(bathymetry_contours.geometry.length.sum(), self.BATHYMETRY_CONTOURS['length'], "The area of " +
                          f"the returned bathymetry_contours polygon `{bathymetry_contours.geometry.length.sum()}` " +
                          "differs from the expected {self.BATHYMETRY_CONTOURS['length']}")
-
 
     def test_bathymetry_no_geometry_name(self):
         """ A test to check expected bathyemtry contours are loaded """


### PR DESCRIPTION
Clean up the vector.Linz class before using it as a template for downloading vector data from LRIS.

Changes:
- [X] Allow the class to be used to download all features in a layer if no search polygon is specified
- [x] Try default the LINZ 'geometry_names' in turn if no 'geometry_name' is specified
- [X] Add a test for downloading all feature values (i.e. no search polygon)
- [X] Add a test for not specifying the 'geometry_name' - add to existing test.