### PR TITLE
15 traceback no features in bounds

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+DESCRIPTION OF PR:
+
+ - [ ] Make code change
+ - [ ] Update tests
+   - [ ] Update / create new tests
+   - [ ] Ensure these tests have the expected behavour
+   - [ ] Test locally and ensure tests are passing
+ - [ ] Ensure tests passing on GH Actions
+ - [ ] Update documentation
+   - [ ] Doc strings
+   - [ ] Wiki

--- a/src/geoapis/__init__.py
+++ b/src/geoapis/__init__.py
@@ -4,4 +4,4 @@ Created on Thu Jul  1 09:57:30 2021
 
 @author: pearsonra
 """
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/src/geoapis/lidar.py
+++ b/src/geoapis/lidar.py
@@ -119,7 +119,6 @@ class OpenTopography:
             response = client.head_object(Bucket=self.OT_BUCKET, Key=file_prefix)
             assert response['ResponseMetadata'][
                 'HTTPStatusCode'] == 200, f"No tile index file exists with key: {file_prefix}"
-            self.response = response
 
             # ensure folder exists before download
             local_file_path.parent.mkdir(parents=True, exist_ok=True)
@@ -140,7 +139,6 @@ class OpenTopography:
             file_prefix = dataset_prefix + "/" + tile_name
             local_path = self.cache_path / file_prefix
             if self.redownload_files_bool or not local_path.exists():
-                print(file_prefix)
                 response = client.head_object(Bucket=self.OT_BUCKET, Key=file_prefix)
                 assert response['ResponseMetadata'][
                     'HTTPStatusCode'] == 200, f"No tile file exists with key: {file_prefix}"

--- a/src/geoapis/vector.py
+++ b/src/geoapis/vector.py
@@ -168,6 +168,7 @@ class WfsQueryBase(abc.ABC):
         if len(features['geometry']) > 0:
             features = geopandas.GeoDataFrame(features, crs=feature_collection['crs']['properties']['name'])
         else:
+            # Return None if no vector features were within the WFS BBox search query
             features = None
 
         return features

--- a/src/geoapis/vector.py
+++ b/src/geoapis/vector.py
@@ -140,7 +140,6 @@ class WfsQueryBase(abc.ABC):
 
         # get feature information from query
         feature_collection = self.get_json_response_in_bounds(layer, catchment_bounds, geometry_name)
-        crs = feature_collection['crs']['properties']['name']
 
         # Cycle through each feature checking in bounds and getting geometry and properties
         features = {'geometry': []}
@@ -166,8 +165,8 @@ class WfsQueryBase(abc.ABC):
                     features[key].append(feature['properties'][key])
 
         # Convert to a geopandas dataframe
-        if len(features) > 0:
-            features = geopandas.GeoDataFrame(features, crs=crs)
+        if len(features['geometry']) > 0:
+            features = geopandas.GeoDataFrame(features, crs=feature_collection['crs']['properties']['name'])
         else:
             features = None
 

--- a/tests/test_vector_linz/test_vector_linz.py
+++ b/tests/test_vector_linz/test_vector_linz.py
@@ -88,7 +88,7 @@ class LinzVectorsTest(unittest.TestCase):
                          "{benchmark['length']}")
 
     def test_50781(self):
-        """ Test expacted entire layer loaded correctly """
+        """ Test expected entire layer loaded correctly """
 
         features = self.runner.run(self.instructions['instructions']['apis']['linz']['railways']['layers'][0])
         description = "railways centre lines"
@@ -98,7 +98,7 @@ class LinzVectorsTest(unittest.TestCase):
         self.compare_to_benchmark(features, benchmark, description, 'id')
 
     def test_51572(self):
-        """ Test expacted entire layer loaded correctly """
+        """ Test expected entire layer loaded correctly """
 
         features = self.runner.run(self.instructions['instructions']['apis']['linz']['pastural_lease']['layers'][0])
         description = "pastural lease parcels"

--- a/tests/test_vector_linz_in_bounds/instruction.json
+++ b/tests/test_vector_linz_in_bounds/instruction.json
@@ -13,6 +13,10 @@
 			"bathymetry_contours": {
 				"layers": [50448],
 				"geometry_name": "shape"
+			},
+			"chatham_contours": {
+				"layers": [50072],
+				"geometry_name": "GEOMETRY"
 			}
 		}
 	}

--- a/tests/test_vector_linz_in_bounds/test_vector_linz_in_bounds.py
+++ b/tests/test_vector_linz_in_bounds/test_vector_linz_in_bounds.py
@@ -26,6 +26,8 @@ class LinzVectorsTest(unittest.TestCase):
         * test_51153_no_geometry_name - Test the specified layer and bbox, but with no geometry_name given
         * test_50448 - Test the specified layer features are correctly downloaded within the specified bbox
         * test_50448_no_geometry_name - Test the specified layer and bbox, but with no geometry_name given
+        * test_50072 - Test the specified layer features are correctly downloaded within the specified bbox
+        * test_50072_no_geometry_name - Test the specified layer and bbox, but with no geometry_name given
     See the associated description for keywords that can be used to search for the layer in the data service.
     """
 
@@ -37,6 +39,7 @@ class LinzVectorsTest(unittest.TestCase):
                            'columns': ['geometry', 'fidn', 'valdco', 'verdat', 'inform', 'ninfom', 'ntxtds',
                                        'scamin', 'txtdsc', 'sordat', 'sorind', 'hypcat'],
                            'valdco': [2.0, 2.0, 0.0, 0.0, 0.0]}
+    CHATHAM_CONTOURS = None
 
     @classmethod
     def setUpClass(cls):
@@ -154,6 +157,31 @@ class LinzVectorsTest(unittest.TestCase):
 
         # check various shape attributes match those expected
         self.compare_to_benchmark(features, benchmark, description, 'valdco')
+
+    def test_50072(self):
+        """ Test expected features of layer loaded """
+
+        features = self.runner.run(
+            self.instructions['instructions']['apis']['linz']['chatham_contours']['layers'][0],
+            self.instructions['instructions']['apis']['linz']['chatham_contours']['geometry_name'])
+        description = "Chatham Island contours"
+        benchmark = self.CHATHAM_CONTOURS
+
+        # check various shape attributes match those expected
+        assert features is benchmark, "No features should have been returned as the WFS search BBox does not overlap with" + \
+            f" the {description} extents. Instead {features} was returned."
+
+    def test_50072_no_geometry_name(self):
+        """ Test expected features of layer loaded without specifying the geometry_name """
+
+        features = self.runner.run(
+            self.instructions['instructions']['apis']['linz']['chatham_contours']['layers'][0])
+        description = "Chatham Island contours"
+        benchmark = self.CHATHAM_CONTOURS
+
+        # check various shape attributes match those expected
+        assert features is benchmark, "No features should have been returned as the WFS search BBox does not overlap with" + \
+            f" the {description} extents. Instead {features} was returned."
 
 
 if __name__ == '__main__':

--- a/tests/test_vector_linz_in_bounds/test_vector_linz_in_bounds.py
+++ b/tests/test_vector_linz_in_bounds/test_vector_linz_in_bounds.py
@@ -112,7 +112,7 @@ class LinzVectorsTest(unittest.TestCase):
                          "{benchmark['length']}")
 
     def test_51153(self):
-        """ Test expacted features of layer loaded """
+        """ Test expected features of layer loaded """
 
         features = self.runner.run(self.instructions['instructions']['apis']['linz']['land']['layers'][0],
                                    self.instructions['instructions']['apis']['linz']['land']['geometry_name'])
@@ -123,7 +123,7 @@ class LinzVectorsTest(unittest.TestCase):
         self.compare_to_benchmark(features, benchmark, description, 'name')
 
     def test_51153_no_geometry_name(self):
-        """ Test expacted features of layer loaded without specifying the geometry_name """
+        """ Test expected features of layer loaded without specifying the geometry_name """
 
         features = self.runner.run(self.instructions['instructions']['apis']['linz']['land']['layers'][0])
         description = "1:50k island polygons"
@@ -133,7 +133,7 @@ class LinzVectorsTest(unittest.TestCase):
         self.compare_to_benchmark(features, benchmark, description, 'name')
 
     def test_50448(self):
-        """ Test expacted features of layer loaded """
+        """ Test expected features of layer loaded """
 
         features = self.runner.run(
             self.instructions['instructions']['apis']['linz']['bathymetry_contours']['layers'][0],
@@ -145,7 +145,7 @@ class LinzVectorsTest(unittest.TestCase):
         self.compare_to_benchmark(features, benchmark, description, 'valdco')
 
     def test_50448_no_geometry_name(self):
-        """ Test expacted features of layer loaded without specifying the geometry_name """
+        """ Test expected features of layer loaded without specifying the geometry_name """
 
         features = self.runner.run(
             self.instructions['instructions']['apis']['linz']['bathymetry_contours']['layers'][0])

--- a/tests/test_vector_lris/test_vector_lris.py
+++ b/tests/test_vector_lris/test_vector_lris.py
@@ -91,7 +91,7 @@ class LrisVectorsTest(unittest.TestCase):
                          "{benchmark['length']}")
 
     def test_48556(self):
-        """ Test expacted entire layer loaded correctly """
+        """ Test expected entire layer loaded correctly """
 
         features = self.runner.run(self.instructions['instructions']['apis']['lris']['northland_erosions']['layers'][0])
         description = "Northand Erosion"
@@ -101,7 +101,7 @@ class LrisVectorsTest(unittest.TestCase):
         self.compare_to_benchmark(features, benchmark, description, 'Area')
 
     def test_48155(self):
-        """ Test expacted entire layer loaded correctly """
+        """ Test expected entire layer loaded correctly """
 
         features = self.runner.run(self.instructions['instructions']['apis']['lris']['pukekohe_soils']['layers'][0])
         description = "Soils in Pukekohe Borough"

--- a/tests/test_vector_lris_in_bounds/test_vector_lris_in_bounds.py
+++ b/tests/test_vector_lris_in_bounds/test_vector_lris_in_bounds.py
@@ -116,7 +116,7 @@ class LrisVectorsTest(unittest.TestCase):
                          "{benchmark['length']}")
 
     def test_105112(self):
-        """ Test expacted features of layer loaded """
+        """ Test expected features of layer loaded """
 
         features = self.runner.run(
             self.instructions['instructions']['apis']['lris']['ni_pature_productivity']['layers'][0],
@@ -128,7 +128,7 @@ class LrisVectorsTest(unittest.TestCase):
         self.compare_to_benchmark(features, benchmark, description, 'uid')
 
     def test_105112_no_geometry_name(self):
-        """ Test expacted features of layer loaded without specifying the geometry_name """
+        """ Test expected features of layer loaded without specifying the geometry_name """
 
         features = self.runner.run(
             self.instructions['instructions']['apis']['lris']['ni_pature_productivity']['layers'][0])
@@ -139,7 +139,7 @@ class LrisVectorsTest(unittest.TestCase):
         self.compare_to_benchmark(features, benchmark, description, 'uid')
 
     def test_104400(self):
-        """ Test expacted features of layer loaded """
+        """ Test expected features of layer loaded """
 
         features = self.runner.run(
             self.instructions['instructions']['apis']['lris']['land_cover_database']['layers'][0],
@@ -151,7 +151,7 @@ class LrisVectorsTest(unittest.TestCase):
         self.compare_to_benchmark(features, benchmark, description, 'Class_2018')
 
     def test_104400_no_geometry_name(self):
-        """ Test expacted features of layer loaded without specifying the geometry_name """
+        """ Test expected features of layer loaded without specifying the geometry_name """
 
         features = self.runner.run(
             self.instructions['instructions']['apis']['lris']['land_cover_database']['layers'][0])


### PR DESCRIPTION
Bug fix - changes to eliminate the trace back when no vector features are within the specified WFS BBox:
 - [X] Make code change
 - [x] Update tests 
   - [x] Update / create new tests
   - [x] Ensure these tests have the expected behavour
   - [X] Test locally and ensure tests are passing
 - [x] Ensure tests passing on GH Actions
 - [X] Update documentation
   - [X] Doc strings
   - [X] Wiki 